### PR TITLE
🎨 Palette: Add loading state to Test Connection button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-01-20 - Adding Visual Feedback to Async Operations in Tkinter
+**Learning:** Found an async operation (API test connection) tied to a button click in `ui/settings.py` without immediate visual feedback. Users could spam click the "Test Connection" button leading to duplicate async requests.
+**Action:** When working with async operations launched from Tkinter buttons via threading, always update the button state (e.g., `state="disabled"`, `text="Testing..."`) synchronously before launching the background thread. Use `root.after(0, ...)` inside the thread to safely schedule the restoration of the button state and text to avoid cross-thread UI manipulation issues. This prevents duplicate submissions and provides clarity to the user.

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 mock_httpx = MagicMock()
 sys.modules["httpx"] = mock_httpx
 
-from utils.updater import is_newer_version
+from utils.updater import is_newer_version  # noqa: E402
 
 def test_is_newer_version_basic():
     assert is_newer_version("1.0.1", "1.0.0") is True

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -93,11 +93,20 @@ def _build_settings_ui(root: tk.Tk, config: AppConfig, result: dict) -> None:
                     messages=[{"role": "user", "content": "ping"}],
                     max_tokens=1,
                 )
-                root.after(0, lambda: messagebox.showinfo("测试成功", "连接正常，API Key 有效", parent=root))
+
+                def _on_success() -> None:
+                    test_btn.config(state="normal", text="测试连接")
+                    messagebox.showinfo("测试成功", "连接正常，API Key 有效", parent=root)
+                root.after(0, _on_success)
             except Exception as exc:
                 err = str(exc)
-                root.after(0, lambda msg=err: messagebox.showerror("测试失败", msg, parent=root))
 
+                def _on_error() -> None:
+                    test_btn.config(state="normal", text="测试连接")
+                    messagebox.showerror("测试失败", err, parent=root)
+                root.after(0, _on_error)
+
+        test_btn.config(state="disabled", text="测试中...")
         threading.Thread(target=_worker, daemon=True).start()
 
     def on_save() -> None:
@@ -133,7 +142,8 @@ def _build_settings_ui(root: tk.Tk, config: AppConfig, result: dict) -> None:
     def on_cancel() -> None:
         root.destroy()
 
-    tk.Button(root, text="测试连接", command=_test_connection, width=10).grid(row=7, column=0, padx=10, pady=10)
+    test_btn = tk.Button(root, text="测试连接", command=_test_connection, width=10)
+    test_btn.grid(row=7, column=0, padx=10, pady=10)
     tk.Button(root, text="保存", command=on_save, width=10).grid(row=7, column=1, padx=10, pady=10, sticky="e")
     tk.Button(root, text="取消", command=on_cancel, width=10).grid(row=7, column=2, padx=10, pady=10, sticky="e")
 


### PR DESCRIPTION
💡 **What:** Added a loading state (disabling the button and changing text to "测试中...") to the "测试连接" (Test Connection) button in the settings menu during the asynchronous API call.
🎯 **Why:** Users lacked immediate visual feedback when testing their API key, making it possible to spam click the button and trigger duplicate background requests. This change clarifies the system status and prevents accidental double-submissions.
📸 **Before/After:** The button now visually disables during the request instead of remaining active.
♿ **Accessibility:** Prevents duplicate form submission states and improves clarity for keyboard users who might actuate the button repeatedly without visual cues of a pending request.

---
*PR created automatically by Jules for task [1025101563840824774](https://jules.google.com/task/1025101563840824774) started by @HCID274*